### PR TITLE
Fix new OAuthConnections always being GitHub

### DIFF
--- a/src/components/views/User/Edit.tsx
+++ b/src/components/views/User/Edit.tsx
@@ -666,7 +666,9 @@ export default withRouter(
                                             newOAuthConnections: [
                                                 ...prev.newOAuthConnections,
                                                 {
-                                                    provider: OAuthProvider.GitHub,
+                                                    provider: Object.keys(
+                                                        oAuthProviderInfos
+                                                    )[0] as OAuthProvider,
                                                     externalUserId: ""
                                                 }
                                             ]


### PR DESCRIPTION
Instead set it to the first available provider