### PR TITLE
There doesn't need to be two pages for instance metadata

### DIFF
--- a/src/components/views/Instance/Edit/Config.tsx
+++ b/src/components/views/Instance/Edit/Config.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { FormattedMessage } from "react-intl";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 
 import {
@@ -99,6 +100,9 @@ class InstanceSettings extends React.Component<IProps, IState> {
 
         return (
             <div className="text-center">
+                <h1>
+                    <FormattedMessage id="view.instance.info" />
+                </h1>
                 <DebugJsonViewer obj={this.context} />
                 {this.state.errors.map((err, index) => {
                     if (!err) return;

--- a/src/components/views/Instance/InstanceEdit.tsx
+++ b/src/components/views/Instance/InstanceEdit.tsx
@@ -30,7 +30,6 @@ import Loading from "../../utils/Loading";
 import WIPNotice from "../../utils/WIPNotice";
 import Byond from "./Edit/Byond";
 import Config from "./Edit/Config";
-import InstanceSettings from "./Edit/Config";
 import { Deployment } from "./Edit/Deployment";
 import JobHistory from "./Edit/JobHistory";
 import Repository from "./Edit/Repository";

--- a/src/components/views/Instance/InstanceEdit.tsx
+++ b/src/components/views/Instance/InstanceEdit.tsx
@@ -29,6 +29,7 @@ import AccessDenied from "../../utils/AccessDenied";
 import Loading from "../../utils/Loading";
 import WIPNotice from "../../utils/WIPNotice";
 import Byond from "./Edit/Byond";
+import Config from "./Edit/Config";
 import InstanceSettings from "./Edit/Config";
 import { Deployment } from "./Edit/Deployment";
 import JobHistory from "./Edit/JobHistory";
@@ -99,7 +100,7 @@ class InstanceEdit extends React.Component<IProps, IState> {
         ) => boolean,
         ComponentType?
     ][] = [
-        ["info", "info", () => true],
+        ["info", "info", () => true, Config],
         [
             "repository",
             "code-branch",
@@ -129,8 +130,7 @@ class InstanceEdit extends React.Component<IProps, IState> {
         ["chatbots", "comments", () => true],
         ["files", "folder-open", () => true],
         ["users", "users", () => true],
-        ["jobs", "stream", () => true, JobHistory],
-        ["config", "cogs", () => true, InstanceSettings]
+        ["jobs", "stream", () => true, JobHistory]
     ];
 
     public constructor(props: IProps) {

--- a/src/translations/locales/en.json
+++ b/src/translations/locales/en.json
@@ -220,6 +220,7 @@
     "view.instance.byond.list_denied": "This user does not have the permission to list all installed BYOND versions",
     "view.instance.byond.current_denied": "This user does not have the permission to see the active BYOND version",
     "view.instance.byond.current_version": "Active Version: {version}",
+    "view.instance.info": "Instance Metadata",
     "view.instance.server.status": "Status: ",
     "view.instance.server.status.Offline": "Offline",
     "view.instance.server.status.Restoring": "Restoring",


### PR DESCRIPTION
Moves the instance "Config" to the information page and gives it a header.

Were you planning on using this page for something else @alexkar598?
![image](https://user-images.githubusercontent.com/8171642/192125615-ca796983-0874-476f-ab90-1c36b60608ae.png)
