### PR TITLE
Should not be adding TM comments automatically

### DIFF
--- a/src/components/utils/TestMergeRow.tsx
+++ b/src/components/utils/TestMergeRow.tsx
@@ -27,7 +27,7 @@ interface IProps {
     repoInfo: RepositoryResponse;
     finalState: [commit: string, comment: string] | false;
     onRemove: () => unknown;
-    onSelectCommit: (commit: string, comment: string) => unknown;
+    onSelectCommit: (commit: string, comment: string | null) => unknown;
     onError: (error: InternalError) => unknown;
 }
 
@@ -194,7 +194,7 @@ export default function TestMergeRow({
                                                 e.shiftKey
                                                     ? onSelectCommit(
                                                           pr.head,
-                                                          "No comment set - Fast Update"
+                                                          testmergeinfo?.comment ?? null
                                                       )
                                                     : setShowModal(true)
                                             }
@@ -223,10 +223,7 @@ export default function TestMergeRow({
                                         disabled={!canAdd}
                                         onClick={e =>
                                             e.shiftKey
-                                                ? onSelectCommit(
-                                                      pr.head,
-                                                      "No comment set - Fast Add"
-                                                  )
+                                                ? onSelectCommit(pr.head, null)
                                                 : setShowModal(true)
                                         }>
                                         <FontAwesomeIcon icon="plus" fixedWidth />

--- a/src/components/views/Instance/Edit/Repository.tsx
+++ b/src/components/views/Instance/Edit/Repository.tsx
@@ -88,7 +88,7 @@ export default function Repository(): JSX.Element {
     const [isLoading, setIsLoading] = useState(true);
     const [PRs, setPRs] = useState<PullRequest[] | null>(null);
     const [desiredState, setDesiredState] = useState(
-        new Map<number, [current: boolean, sha: string, comment: string] | false>()
+        new Map<number, [current: boolean, sha: string, comment: string | null] | false>()
     );
     const [updateRepo, setUpdateRepo] = useState(false);
     const [manualPRs, setManualPRs] = useState<Set<number>>(new Set());


### PR DESCRIPTION
Removes Fast Add and Fast Update, auto genned test merge comments. Fast update is replaced with the existing test merge comment.