### PR TITLE
Defaults to showing manuel pr-entry.

### DIFF
--- a/src/ApiClient/util/config.ts
+++ b/src/ApiClient/util/config.ts
@@ -120,7 +120,7 @@ const configOptions = asElementTypesConfig({
     manualpr: {
         id: "config.manualpr",
         type: "bool",
-        value: false
+        value: true
     }
 });
 


### PR DESCRIPTION
Until you make a way for server owners to control these defaults for their users (allowing them to override them) you have to understand that it is more annoying to have to train somebody to enable a feature they will need then letting them figure out they can hide it if they don't need it.