### PR TITLE
Adds merge conflict label badge

### DIFF
--- a/src/components/utils/TestMergeRow.tsx
+++ b/src/components/utils/TestMergeRow.tsx
@@ -161,6 +161,11 @@ export default function TestMergeRow({
                             <FormattedMessage id="view.instance.repo.testmergelabel" />
                         </Badge>
                     ) : null}
+                    {pr.conflictlabel ? (
+                        <Badge pill className="text-white text-capitalize mr-2" variant="danger">
+                            <FormattedMessage id="view.instance.repo.conflictlabel" />
+                        </Badge>
+                    ) : null}
                 </td>
                 <td>
                     <a href={pr.link} target="_blank" rel="noreferrer">

--- a/src/components/views/Instance/Edit/Repository.tsx
+++ b/src/components/views/Instance/Edit/Repository.tsx
@@ -958,6 +958,9 @@ class Repository extends React.Component<IProps, IState> {
                 if (a.testmergelabel !== b.testmergelabel) {
                     return a.testmergelabel ? -1 : 1;
                 }
+                if (a.conflictlabel !== b.conflictlabel) {
+                    return a.conflictlabel ? 1 : -1;
+                }
                 return a.number - b.number;
             }) ?? [];
         const filteredPendingActions = sortedPRs

--- a/src/translations/locales/en.json
+++ b/src/translations/locales/en.json
@@ -416,6 +416,7 @@
     "view.instance.repo.manual.desc": "Use this box to manually test merge a pull/merge request by entering its number and clicking \"Add Test Merge\"",
     "view.instance.repo.addmanual": "Add Test Merge",
     "view.instance.repo.testmergelabel": "Labelled",
+    "view.instance.repo.conflictlabel": "Merge Conflict",
     "view.instance.repo.norepoinfo": "You lack the permission to display information about the repository",
     "view.instance.repo.delete.title": "Delete Repository",
     "view.instance.repo.delete.desc": "This will delete the local copy of the repository. Instance settings, code modifications, event scripts and static files will be preserved.",

--- a/src/utils/GithubClient.ts
+++ b/src/utils/GithubClient.ts
@@ -34,6 +34,7 @@ export interface PullRequest {
     head: string;
     tail: string;
     testmergelabel: boolean;
+    conflictlabel: boolean;
 }
 
 type ExtractArrayType<A> = A extends Array<infer ArrayType> ? ArrayType : never;
@@ -221,6 +222,9 @@ const e = new (class GithubClient extends TypedEmitter<IEvents> {
                 label =>
                     label.name?.toLowerCase().includes("testmerge") ||
                     label.name?.toLowerCase().includes("test merge")
+            ),
+            conflictlabel: pr.labels.some(
+                label => label.name?.toLowerCase().includes("conflict")
             )
         };
     }

--- a/src/utils/GithubClient.ts
+++ b/src/utils/GithubClient.ts
@@ -223,9 +223,7 @@ const e = new (class GithubClient extends TypedEmitter<IEvents> {
                     label.name?.toLowerCase().includes("testmerge") ||
                     label.name?.toLowerCase().includes("test merge")
             ),
-            conflictlabel: pr.labels.some(
-                label => label.name?.toLowerCase().includes("conflict")
-            )
+            conflictlabel: pr.labels.some(label => label.name?.toLowerCase().includes("conflict"))
         };
     }
 


### PR DESCRIPTION
Basically just dupes the code for "test merge candidate" or similar for "merge conflict" labels which many major codebases who use TGS already have. I'm tired of having to cross-reference the github PRs list to see what conflicts when there's a system that would do the same thing much more conveniently.

Yes, there's another way to [check mergeability](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests) but that's more complicated and this works fine imo. 

Also, yes, this only shows if there's a conflict with the branch it's targeting with no other added PRs, which could lead to some confusion as to why a PR that doesn't have this badge conflicts, but I honestly don't think that's worth comparing to the convenience of knowing which PRs are *guaranteed* to conflict. I can change it to "Conflicts with target branch" or something if need be.