### PR TITLE
Remove container margins on smaller (unsupported) displays.

### DIFF
--- a/src/styles/dark.scss
+++ b/src/styles/dark.scss
@@ -505,4 +505,11 @@ $toast-header-background-color: $gray-600;
     line-height: inherit;
 }
 
+//Remove container margins on smaller (unsupported) displays.
+@media (max-width: 991px) {
+    .container-md, .container-sm, .container {
+        max-width: unset !important;
+    }
+}
+
 @import "./select.scss";


### PR DESCRIPTION
The whole max-width thing has always been kinda silly. The chosen viewport sizes are always monitor widths which assumes that somebody isn't gonna have a browser window smaller than their monitor but they will. Be it vertical taskbars, or tiling window managers or just doing a windows 7 and up drag to the side split screen, this assumption just doesn't hold up. having the page have a width of 720px unless i can get the viewpoint to exactly 992px or higher is silly ya know?

None the less thats all bootstrap side, not us, so this will work for the primary case the bootstrap way shows its flaws.


For those of you with access, this is live on campbell's tgs on the v5.2.4 tag of my fork but should work just as well on current.

this is still not ideal: 

![image](https://github.com/tgstation/tgstation-server-webpanel/assets/7069733/8e4ff3de-6dde-4956-ab1e-372fc894232e)

but its better than this
![image](https://github.com/tgstation/tgstation-server-webpanel/assets/7069733/5ff5e6b4-aaf1-4138-9db5-431c14737b8b)

(viewport of ~900px, 1024px portrait monitor with a vertical taskbar)
