### PR TITLE
Mergeability Polling Interval Config, Mergeability Tidying

### DIFF
--- a/src/ApiClient/util/config.ts
+++ b/src/ApiClient/util/config.ts
@@ -126,6 +126,11 @@ const configOptions = asElementTypesConfig({
         id: "config.restjobs2",
         type: "bool",
         value: false
+    },
+    mergeabilitypolltimer: {
+        id: "config.mergeabilitypolltimer",
+        type: "num",
+        value: 5000
     }
 });
 

--- a/src/translations/locales/en.json
+++ b/src/translations/locales/en.json
@@ -701,6 +701,8 @@
     "config.manualreset.desc": "Controls whether or not an input box is displayed to force a repository reset. This option is ignored and the manual PR entry box is always displayed when using a repository hosted on GitLab.",
     "config.restjobs2": "Force HTTP Polling for Job Updates",
     "config.restjobs2.desc": "Workaround for if SignalR job updates are failing",
+    "config.mergeabilitypolltimer": "Mergeability Polling Timer",
+    "config.mergeabilitypolltimer.desc": "After how many seconds we try to poll the mergeability of a PR from github again, in milliseconds",
     "loading.loading": "Loading...",
     "loading.login": "Logging in...",
     "loading.page": "Loading page: ",

--- a/src/translations/locales/en.json
+++ b/src/translations/locales/en.json
@@ -702,7 +702,7 @@
     "config.restjobs2": "Force HTTP Polling for Job Updates",
     "config.restjobs2.desc": "Workaround for if SignalR job updates are failing",
     "config.mergeabilitypolltimer": "Mergeability Polling Timer",
-    "config.mergeabilitypolltimer.desc": "After how many seconds we try to poll the mergeability of a PR from github again, in milliseconds",
+    "config.mergeabilitypolltimer.desc": "After how many milliseconds we try to poll the mergeability of a PR from github again",
     "loading.loading": "Loading...",
     "loading.login": "Logging in...",
     "loading.page": "Loading page: ",

--- a/src/utils/GithubClient.ts
+++ b/src/utils/GithubClient.ts
@@ -222,7 +222,7 @@ const e = new (class GithubClient extends TypedEmitter<IEvents> {
             testmergelabel: pr.labels.some(
                 label =>
                     label.name?.toLowerCase().includes("testmerge") ||
-                label.name?.toLowerCase().includes("test merge")
+                    label.name?.toLowerCase().includes("test merge")
             ),
             mergeable: pr.mergeable
         };

--- a/src/utils/GithubClient.ts
+++ b/src/utils/GithubClient.ts
@@ -326,7 +326,6 @@ const e = new (class GithubClient extends TypedEmitter<IEvents> {
 
                 //Fetch them in parallel to not waste extra time with polling
                 payload = await Promise.all(prPromises);
-
             } else {
                 //Otherwise just use the basic info
                 payload = basicPRInfo.map(this.transformBasicPR);


### PR DESCRIPTION
Apologies I didn't get to this sooner. Basically just adds a config option in the webpanel that determines how long it should wait between re-polling the Github API for the mergeability status of PRs. Not a necessary option, I just figured it shouldn't be a magic number anymore.

Also does a little bit of tidying up, making both branches of getPRs() more or less use the same functions for the sake of consistency.