### PR TITLE
Update default debugging port for chrome

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
             "type": "chrome",
             "request": "launch",
             "name": "Launch Chrome",
-            "url": "http://localhost:3000/tgstation-server-control-panel",
+            "url": "http://localhost:8080/tgstation-server-control-panel",
             "webRoot": "${workspaceFolder}"
         }
     ]


### PR DESCRIPTION
This PR simply updates the default port chrome debug launch option opens with. Firefox (default) already uses 8080.