### PR TITLE
Do not test merge labeling

### DIFF
--- a/src/components/utils/TestMergeRow.tsx
+++ b/src/components/utils/TestMergeRow.tsx
@@ -157,9 +157,14 @@ export default function TestMergeRow({
                         style={{ backgroundColor: colorMap[pr.state] }}>
                         {pr.state}
                     </Badge>
-                    {pr.testmergelabel ? (
+                    {pr.testmergelabel && !pr.antitestmergelabel ? (
                         <Badge pill className="text-white text-capitalize mr-2" variant="primary">
                             <FormattedMessage id="view.instance.repo.testmergelabel" />
+                        </Badge>
+                    ) : null}
+                    {pr.antitestmergelabel ? (
+                        <Badge pill className="text-white text-capitalize mr-2" variant="danger">
+                            <FormattedMessage id="view.instance.repo.antitestmergelabel" />
                         </Badge>
                     ) : null}
                     {pr.mergeable === false ? (

--- a/src/components/views/Instance/Edit/Repository.tsx
+++ b/src/components/views/Instance/Edit/Repository.tsx
@@ -960,6 +960,9 @@ class Repository extends React.Component<IProps, IState> {
                 if (a.testmergelabel !== b.testmergelabel) {
                     return a.testmergelabel ? -1 : 1;
                 }
+                if (a.antitestmergelabel !== b.antitestmergelabel) {
+                    return a.antitestmergelabel ? -1 : 1;
+                }
                 if (a.mergeable !== b.mergeable) {
                     return a.mergeable ? -1 : 1;
                 }

--- a/src/translations/locales/en.json
+++ b/src/translations/locales/en.json
@@ -424,6 +424,7 @@
     "view.instance.repo.manual.desc": "Use this box to manually test merge a pull/merge request by entering its number and clicking \"Add Test Merge\"",
     "view.instance.repo.addmanual": "Add Test Merge",
     "view.instance.repo.testmergelabel": "Labelled",
+    "view.instance.repo.antitestmergelabel": "Block Labelled",
     "view.instance.repo.conflictlabel": "Merge Conflict",
     "view.instance.repo.norepoinfo": "You lack the permission to display information about the repository",
     "view.instance.repo.delete.title": "Delete Repository",

--- a/src/utils/GithubClient.ts
+++ b/src/utils/GithubClient.ts
@@ -35,6 +35,7 @@ export interface PullRequest {
     head: string;
     tail: string;
     testmergelabel: boolean;
+    antitestmergelabel: boolean;
     mergeable: boolean | null;
 }
 
@@ -230,6 +231,11 @@ const e = new (class GithubClient extends TypedEmitter<IEvents> {
                     label.name?.toLowerCase().includes("testmerge") ||
                     label.name?.toLowerCase().includes("test merge")
             ),
+            antitestmergelabel: pr.labels.some(
+                label =>
+                    label.name?.toLowerCase().includes("do not testmerge") ||
+                    label.name?.toLowerCase().includes("do not test merge")
+            ),
             mergeable: pr.mergeable
         };
     }
@@ -253,6 +259,11 @@ const e = new (class GithubClient extends TypedEmitter<IEvents> {
                 label =>
                     label.name?.toLowerCase().includes("testmerge") ||
                     label.name?.toLowerCase().includes("test merge")
+            ),
+            antitestmergelabel: pr.labels.some(
+                label =>
+                    label.name?.toLowerCase().includes("do not testmerge") ||
+                    label.name?.toLowerCase().includes("do not test merge")
             ),
             mergeable: null
         };


### PR DESCRIPTION
This PR adds support for labeling that indicates to not test merge a TM (doesn't prevent any functionality). It checks case insensitive for both `do not testmerge` and `do not test merge`

With a label such as "test merge candidate": (Existing behavior)
<img width="1018" height="81" alt="image" src="https://github.com/user-attachments/assets/c4de127b-0c8e-4658-9e96-2fcfdc79c5b5" />

With both "test merge candidate" and "do not test merge" (or only the latter one) it appears like this:
<img width="1023" height="100" alt="image" src="https://github.com/user-attachments/assets/4d6a6fc9-3608-4589-a9da-35c9043bae43" />
<img width="327" height="111" alt="image" src="https://github.com/user-attachments/assets/b4b4a66d-235f-47cc-88db-080a47ae7c03" />
